### PR TITLE
Clarify Contributing doc

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,6 @@
 This will eventually have more information for both contributing to this project as well as what projects are acceptable for inclusion under DevProgress.
 
-At the very least, all contributors must have a Contributor License Agreement.
-If not, please sign up [here](http://devprogress.us/#joindp).
+Contributors must have a signed CLA. If you do not have one, please sign up [here](http://devprogress.us/#joindp).
+Once you have signed the CLA, you will be added as a member of the `DevProgress` GitHub organization.
+
+If you have signed a CLA, and have not been added to the GitHub organization, please mention `@bradyk` to get it sorted out.


### PR DESCRIPTION
Once a user has signed a CLA, they will be added as a member of the GitHub org.
This means that we don't need an out-of-band check for the CLA.
